### PR TITLE
Support small number (<8) reactions for plot_rxns

### DIFF
--- a/src/permm/core/Mechanism.py
+++ b/src/permm/core/Mechanism.py
@@ -593,6 +593,9 @@ class Mechanism(object):
                     other = self('(%s)' % (rxn,))
         
             reactions = [self('(%s)' % (rxn, )) for rxn in reactions[:nlines-1]] + [other]
+        else:
+            reactions = [self('(%s)' % (rxn, )) for rxn in reactions[:nlines-1]]
+
         reactions = [(rxn.sum()[plot_spc], rxn) for rxn in reactions]
     
         reactions.sort(reverse = False)


### PR DESCRIPTION
Fix #10 .

Example for H2O2 using the test data:

```
python -m permm --gui test.mrg.nc
```

Chosing `OR`, `H2O2` in the "Select Products" column, and `Plot Reactions` in the `Execute` column:

![image](https://user-images.githubusercontent.com/30388627/100405955-af111e00-309f-11eb-83c2-00f66ab866a7.png)

